### PR TITLE
Added usage overview to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ $HOME/.ramp.ini
 
 Valid combinations of parameters and their mapping to paths are as follows:
 
-_ _(`[]`) indicate optional parameters_ _
-_ _(`|`) indicate a list of possible parameters_ _
+_(`[]`) indicate optional parameters_
+_(`|`) indicate a list of possible parameters_
 
 The parameters `location` and `path` are appended to the end of the path and are always optional. If both are specified, `location` is appended first.
 
@@ -39,7 +39,7 @@ The parameters `location` and `path` are appended to the end of the path and are
 <assembled path>/locations/<location>/<path>
 ```
 
-** **input|output [location] project [user] [path (default: NULL)]** ** [^1]
+**input|output [location] project [user] [path (default: NULL)]** [^1]
 
 ```Shell
 projects/<project>/<inputs>
@@ -48,27 +48,27 @@ projects/<project>/<outputs>
 projects/<project>/<outputs>/users/<user>
 ```
 
-** **working [location] project user [path (default: NULL)]** **
+**working [location] project user [path (default: NULL)]**
 
 ```Shell
 projects/<project>/users/<user>
 ```
 
-** **input|output|working [location] rproject [user] [path (default: NULL)]** ** [^2]
+**input|output|working [location] rproject [user] [path (default: NULL)]** [^2]
 
 ```Shell
 libraries/<rproject>/inst/extdata
 libraries/<rproject>/inst/extdata/users/<user>
 ```
 
-** **input [location] [user] [path (default: NULL)]** ** [^3]
+**input [location] [user] [path (default: NULL)]** [^3]
 
 ```Shell
 inputs
 inputs/users/<user>
 ```
 
-** **output|working [location] user [path (default: NULL)]** **
+**output|working [location] user [path (default: NULL)]**
 
 ```Shell
 outputs/users/<user>

--- a/README.md
+++ b/README.md
@@ -26,12 +26,11 @@ $HOME/.config/RAMP/data.ini
 $HOME/.ramp.ini
 ```
 
-#### Valid combinations of parameters and their mapping to paths
+### Valid combinations of parameters and their mapping to paths
 
----
-*Note:*
+**Note:**
 
-`[]` _indicate optional parameters_
+`[]` _indicate optional parameters_\
 `|` _indicates a list of possible parameters_
 
 The parameters `location` and `path` are appended to the end of the path and are always optional. If both are specified, `location` is appended first.

--- a/README.md
+++ b/README.md
@@ -26,11 +26,13 @@ $HOME/.config/RAMP/data.ini
 $HOME/.ramp.ini
 ```
 
-Valid combinations of parameters and their mapping to paths are as follows:
+#### Valid combinations of parameters and their mapping to paths
 
-_(`[]`) indicate optional parameters_
+---
+*Note:*
 
-_(`|`) indicate a list of possible parameters_
+`[]` _indicate optional parameters_
+`|` _indicates a list of possible parameters_
 
 The parameters `location` and `path` are appended to the end of the path and are always optional. If both are specified, `location` is appended first.
 
@@ -39,6 +41,7 @@ The parameters `location` and `path` are appended to the end of the path and are
 <assembled path>/<path>
 <assembled path>/locations/<location>/<path>
 ```
+---
 
 **input|output [location] project [user] [path (default: NULL)]** <sup>1</sup>
 
@@ -76,10 +79,8 @@ outputs/users/<user>
 working/users/<user>
 ```
 
-<sup>1</sup> `user` is optional but ignored
-
-<sup>2</sup> `input|output|working` is required but ignored
-
+<sup>1</sup> `user` is optional but ignored\
+<sup>2</sup> `input|output|working` is required but ignored\
 <sup>3</sup> `user` is optional but ignored
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The parameters `location` and `path` are appended to the end of the path and are
 <assembled path>/locations/<location>/<path>
 ```
 
-**input|output [location] project [user] [path (default: NULL)]** [^1]
+**input|output [location] project [user] [path (default: NULL)]** <sup>1</sup>
 
 ```Shell
 projects/<project>/<inputs>
@@ -54,14 +54,14 @@ projects/<project>/<outputs>/users/<user>
 projects/<project>/users/<user>
 ```
 
-**input|output|working [location] rproject [user] [path (default: NULL)]** [^2]
+**input|output|working [location] rproject [user] [path (default: NULL)]** <sup>2</sup>
 
 ```Shell
 libraries/<rproject>/inst/extdata
 libraries/<rproject>/inst/extdata/users/<user>
 ```
 
-**input [location] [user] [path (default: NULL)]** [^3]
+**input [location] [user] [path (default: NULL)]** <sup>3</sup>
 
 ```Shell
 inputs
@@ -75,11 +75,9 @@ outputs/users/<user>
 working/users/<user>
 ```
 
-
-[^1] user is optional but ignored
-[^2] input|output|working is required but ignored
-[^3] user is optional but ignored
-
+<sup>1</sup> user is optional but ignored
+<sup>2</sup> input|output|working is required but ignored
+<sup>3</sup> user is optional but ignored
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ $HOME/.ramp.ini
 
 Valid combinations of parameters and their mapping to paths are as follows:
 
-   _(`[]`) indicate optional parameters_
-   _(`|`) indicate a list of possible parameters_
+_(`[]`) indicate optional parameters_
+
+_(`|`) indicate a list of possible parameters_
 
 The parameters `location` and `path` are appended to the end of the path and are always optional. If both are specified, `location` is appended first.
 
@@ -75,9 +76,11 @@ outputs/users/<user>
 working/users/<user>
 ```
 
-   <sup>1</sup> `user` is optional but ignored
-   <sup>2</sup> `input|output|working` is required but ignored
-   <sup>3</sup> `user` is optional but ignored
+<sup>1</sup> `user` is optional but ignored
+
+<sup>2</sup> `input|output|working` is required but ignored
+
+<sup>3</sup> `user` is optional but ignored
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ $HOME/.ramp.ini
 
 Valid combinations of parameters and their mapping to paths are as follows:
 
-_(`[]`) indicate optional parameters_
-_(`|`) indicate a list of possible parameters_
+   _(`[]`) indicate optional parameters_
+   _(`|`) indicate a list of possible parameters_
 
 The parameters `location` and `path` are appended to the end of the path and are always optional. If both are specified, `location` is appended first.
 
@@ -75,9 +75,9 @@ outputs/users/<user>
 working/users/<user>
 ```
 
-<sup>1</sup> user is optional but ignored
-<sup>2</sup> input|output|working is required but ignored
-<sup>3</sup> user is optional but ignored
+   <sup>1</sup> `user` is optional but ignored
+   <sup>2</sup> `input|output|working` is required but ignored
+   <sup>3</sup> `user` is optional but ignored
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,85 @@
 
 Reads RAMP project data from an archive.
 
+## Installation
+
 Install the 7zip tool by hand.
 
-```
+```R
 devtools::install_github("jimhester/archive")
 ```
+
+## Usage
+
+Under the hood, paths are assembled by the `ramp_path` function which returns a relative path which can be appended to a root path to generate the full path to the data.
+
+```R
+ramp_path <- function(stage, location, project, user, rproject, path = NULL)
+```
+
+The root path can be specified in one of the following configuration files:
+
+```Shell
+${XDG_CONFIG_HOME}/RAMP/data.ini
+$HOME/.config/RAMP/data.ini
+$HOME/.ramp.ini
+```
+
+Valid combinations of parameters and their mapping to paths are as follows:
+
+_ _(`[]`) indicate optional parameters_ _
+_ _(`|`) indicate a list of possible parameters_ _
+
+The parameters `location` and `path` are appended to the end of the path and are always optional. If both are specified, `location` is appended first.
+
+```Shell
+<assembled path>/locations/<location>
+<assembled path>/<path>
+<assembled path>/locations/<location>/<path>
+```
+
+** **input|output [location] project [user] [path (default: NULL)]** ** [^1]
+
+```Shell
+projects/<project>/<inputs>
+projects/<project>/<inputs>/users/<user>
+projects/<project>/<outputs>
+projects/<project>/<outputs>/users/<user>
+```
+
+** **working [location] project user [path (default: NULL)]** **
+
+```Shell
+projects/<project>/users/<user>
+```
+
+** **input|output|working [location] rproject [user] [path (default: NULL)]** ** [^2]
+
+```Shell
+libraries/<rproject>/inst/extdata
+libraries/<rproject>/inst/extdata/users/<user>
+```
+
+** **input [location] [user] [path (default: NULL)]** ** [^3]
+
+```Shell
+inputs
+inputs/users/<user>
+```
+
+** **output|working [location] user [path (default: NULL)]** **
+
+```Shell
+outputs/users/<user>
+working/users/<user>
+```
+
+
+[^1] user is optional but ignored
+[^2] input|output|working is required but ignored
+[^3] user is optional but ignored
+
+
+## Credits
 
 Ramp image from https://www.flickr.com/photos/chrisfurniss/.


### PR DESCRIPTION
I added some usage info to the front page. Even though it's not what you interact with directly it discusses `ramp_path` because that's where the mapping between keywords and directory structure happens.

@aucarter @erhilton I need someone to tell me whether this is actually helpful or not. I want to make this easy enough for people to use that everyone adopts it.